### PR TITLE
fix initialization with async attribute

### DIFF
--- a/closeio_api/__init__.py
+++ b/closeio_api/__init__.py
@@ -105,7 +105,7 @@ class Client(API):
             base_url = 'http://localhost:5001/api/v1/'
         else:
             base_url = 'https://app.close.io/api/v1/'
-        super(Client, self).__init__(base_url, api_key, tz_offset=None, async=False)
+        super(Client, self).__init__(base_url, api_key, tz_offset=None, async=async)
 
 
 


### PR DESCRIPTION
`Client(api_key=MY_KEY, async=True)` was totally ignored, now it should correctly initialize an async client when you pass `async=True`.